### PR TITLE
Fixed build of libfastjson

### DIFF
--- a/package/libfastjson/libfastjson.hash
+++ b/package/libfastjson/libfastjson.hash
@@ -1,2 +1,2 @@
 # Locally calculated
-sha256  fcdca0c4702362de3db3f02c8da05f985b54a9eccd618af41730409b75d10a8f  libfastjson-v0.99.2.tar.gz
+sha256  fcdca0c4702362de3db3f02c8da05f985b54a9eccd618af41730409b75d10a8f  v0.99.2.tar.gz

--- a/package/libfastjson/libfastjson.mk
+++ b/package/libfastjson/libfastjson.mk
@@ -4,8 +4,9 @@
 #
 ################################################################################
 
-LIBFASTJSON_VERSION = v0.99.2
+LIBFASTJSON_VERSION = 0.99.2
 LIBFASTJSON_SITE = $(call github,rsyslog,libfastjson,$(LIBFASTJSON_VERSION))
+LIBFASTJSON_SOURCE = v$(LIBFASTJSON_VERSION).tar.gz
 LIBFASTJSON_INSTALL_STAGING = YES
 # From git
 LIBFASTJSON_AUTORECONF = YES


### PR DESCRIPTION
The hash was referencing a non-existing file. Similar for the make file. Both is now corrected.

Side note: I did not update libfastjson to the newest version (0.99.4). Would that have been ok?