### PR TITLE
package/gdb: do not remove support files if python is chosen

### DIFF
--- a/package/gdb/gdb.mk
+++ b/package/gdb/gdb.mk
@@ -164,11 +164,13 @@ endif
 
 # This removes some unneeded Python scripts and XML target description
 # files that are not useful for a normal usage of the debugger.
+ifneq ($(BR2_PACKAGE_GDB_PYTHON),y)
 define GDB_REMOVE_UNNEEDED_FILES
 	$(RM) -rf $(TARGET_DIR)/usr/share/gdb
 endef
 
 GDB_POST_INSTALL_TARGET_HOOKS += GDB_REMOVE_UNNEEDED_FILES
+endif
 
 # This installs the gdbserver somewhere into the $(HOST_DIR) so that
 # it becomes an integral part of the SDK, if the toolchain generated


### PR DESCRIPTION
If one wants to use GDB with python support on the target, you need the support files installed by GDB. These get usually deleted to save some space, so I just wrapped the Makefile code deleting them in a conditional block depending on if python support is active or not.