### PR TITLE
Align dtb blob by 8 bytes in BR2_LINUX_KERNEL_APPENDED_DTB

### DIFF
--- a/linux/linux.mk
+++ b/linux/linux.mk
@@ -383,7 +383,8 @@ define LINUX_APPEND_DTB
 			else \
 				dtbpath=dts/$${dtb}.dtb ; \
 			fi ; \
-			cat zImage $${dtbpath} > zImage.$${dtb} || exit 1; \
+			dd if=$${dtbpath} of=$${dtbpath}.padded ibs=8 conv=sync;\
+			cat zImage $${dtbpath}.padded > zImage.$${dtb} || exit 1; \
 		done)
 endef
 ifeq ($(BR2_LINUX_KERNEL_APPENDED_UIMAGE),y)


### PR DESCRIPTION
Appended DTB should be aligned. When kernel use unpadded DTB blob, it becomes corrupted