### PR TITLE
Add libvirt (KVM) support

### DIFF
--- a/support/misc/Vagrantfile
+++ b/support/misc/Vagrantfile
@@ -29,6 +29,12 @@ Vagrant.configure('2') do |config|
 		end
 	end
 
+  config.vm.provider :libvirt do |v, override|
+    override.vm.box = 'generic/ubuntu1804'
+    v.memory = VM_MEMORY
+    v.cpus = VM_CORES
+  end 
+
 	config.vm.provision 'shell' do |s|
 		s.inline = 'echo Setting up machine name'
 


### PR DESCRIPTION
This commit will enable users to use the Vagrantfile with vagrant-libvirt.

Please notice the `override.vm.box` on line 33 which overrides the box name.
This is because the `ubuntu/bionic64` box only supports VirtualBox.

This might also be required to be overridden for the `vmware_fusion` provider since this provider is also not supported by `ubuntu/bionic64`. I'm not a Mac user myself. Should I create an issue to have this investigated?