### PR TITLE
package/connman: fix legacy wpa_supplicant dbus select

### DIFF
--- a/package/connman/Config.in
+++ b/package/connman/Config.in
@@ -25,7 +25,7 @@ config BR2_PACKAGE_CONNMAN_ETHERNET
 config BR2_PACKAGE_CONNMAN_WIFI
 	bool "enable WiFi support"
 	select BR2_PACKAGE_WPA_SUPPLICANT # runtime
-	select BR2_PACKAGE_WPA_SUPPLICANT_DBUS_NEW # runtime
+	select BR2_PACKAGE_WPA_SUPPLICANT_DBUS # runtime
 	help
 	  Enable WiFi support (scan and static/dhcp interface
 	  setup). ConnMan detects the start of wpa_supplicant


### PR DESCRIPTION
Remove '_NEW' from 'select BR2_PACKAGE_WPA_SUPPLICANT_DBUS_NEW' in Config.in.

Wpa_supplicant dbus support option has been renamed from 'BR2_PACKAGE_WPA_SUPPLICANT_DBUS_NEW' to
'BR2_PACKAGE_WPA_SUPPLICANT_DBUS' in v2.9 bump (f2ffdbee2aca0ca2bde469475c180d60cb934beb).
While Connman package, which depends on wpa_supplicant, has not been updated.

This patch will fix legacy build error.

Signed-off-by: sandwichdoge <sandwichdoge@gmail.com>