### PR TITLE
fix corrupted download url of extra packages

### DIFF
--- a/package/pkg-generic.mk
+++ b/package/pkg-generic.mk
@@ -523,8 +523,9 @@ endif
 $(2)_ALL_DOWNLOADS = \
 	$$(if $$($(2)_SOURCE),$$($(2)_SITE_METHOD)+$$($(2)_SITE)/$$($(2)_SOURCE)) \
 	$$(foreach p,$$($(2)_PATCH) $$($(2)_EXTRA_DOWNLOADS),\
-		$$(if $$(findstring ://,$$(p)),$$(p),\
-			$$($(2)_SITE)/$$(p)))
+		$$(call getschemeplusuri,$$(call qstrip,\
+		  $$(if $$(findstring ://,$$(p)),$$(p),\
+			  $$($(2)_SITE)/$$(p))),urlencode))
 
 ifndef $(2)_SITE
  ifdef $(3)_SITE


### PR DESCRIPTION
While downloading pacakges, the `SITE_METHOD` will be prefixed to the download url of the main package, but the extra download url would not be. If the `SITE URL` accidentally includes '+', url link before '+' would be parsed as `SITE METHOD` by dl-wrapper, and the url broken.

Take `android-tools` package for example:
```
ANDROID_TOOLS_SITE = https://launchpad.net/ubuntu/+archive/primary/+files
ANDROID_TOOLS_EXTRA_DOWNLOADS = android-tools_$(ANDROID_TOOLS_VERSION)-3ubuntu41.debian.tar.gz
```

while build the android-tools package, `ALL_DOWNLOADS` will be expended as:

```
for p in https+https://launchpad.net/ubuntu/+archive/primary/+files/android-tools_4.2.2+git20130218.orig.tar.xz   https://launchpad.ne
t/ubuntu/+archive/primary/+files/android-tools_4.2.2+git20130218-3ubuntu41.debian.tar.gz; do \
        if test ! -e /mnt/fileroot/jun.zhang/buildroot-git/buildroot/dl/android-tools/`basename $p` ; then \
                echo ">>> android-tools 4.2.2+git20130218 Downloading" ; \
                break ; \
        fi ; \
done
```

Notice that there's no 'https+' prefixed to the url, `SITE_MOTHOD` missing.

and while downloading package, url corrupted:

>--2019-11-05 14:10:29--  http://archive/primary/+files/android-tools_4.2.2+git20130218-3ubuntu41.debian.tar.gz

