### PR TITLE
package/sysrepo: fix host configure option

### DIFF
--- a/package/sysrepo/sysrepo.mk
+++ b/package/sysrepo/sysrepo.mk
@@ -58,7 +58,7 @@ HOST_SYSREPO_CONF_OPTS = \
 	-DCALL_TARGET_BINS_DIRECTLY=OFF \
 	-DBUILD_EXAMPLES=OFF \
 	-DBUILD_CPP_EXAMPLES=OFF \
-	-DREPOSITORY_LOC=$(HOST_DIR)/etc/sysrepo \
+	-DREPOSITORY_LOC=$(TARGET_DIR)/etc/sysrepo \
 	-DSUBSCRIPTIONS_SOCKET_DIR=$(HOST_DIR)/var/run/sysrepo-subscriptions
 
 $(eval $(cmake-package))


### PR DESCRIPTION
Host-sysrepoctl should install yang modules to TARGET
directory.

Signed-off-by: Xiaolin He <xiaolin.he@nxp.com>