### PR TITLE
package/shairport-sync: don't run shairport as root

### DIFF
--- a/package/shairport-sync/S99shairport-sync
+++ b/package/shairport-sync/S99shairport-sync
@@ -6,7 +6,8 @@ OPTIONS="-d"
 case "$1" in
     start)
 	printf "Starting shairport-sync: "
-	start-stop-daemon -S -q --exec /usr/bin/shairport-sync -- $OPTIONS
+	start-stop-daemon -S -q -c pulseaudio-sync \
+		--exec /usr/bin/shairport-sync -- $OPTIONS
 	[ $? = 0 ] && echo "OK" || echo "FAIL"
 	;;
     stop)

--- a/package/shairport-sync/shairport-sync.mk
+++ b/package/shairport-sync/shairport-sync.mk
@@ -83,4 +83,14 @@ define SHAIRPORT_SYNC_INSTALL_INIT_SYSV
 		$(TARGET_DIR)/etc/init.d/S99shairport-sync
 endef
 
+ifeq ($(BR2_PACKAGE_PULSEAUDIO),y)
+define SHAIRPORT_SYNC_USERS
+	shairport-sync -1 shairport-sync -1 * /var/run/shairport-sync - audio,pulse-access
+enddef
+else
+define SHAIRPORT_SYNC_USERS
+	shairport-sync -1 shairport-sync -1 * /var/run/shairport-sync - audio
+enddef
+endif
+
 $(eval $(autotools-package))


### PR DESCRIPTION
Run shairport as user `shairport-sync`. If pulseaudio gets installed,
the user gets added to the group `pulse-access` to make volume-control
work.

Signed-off-by: Michael Niewöhner <foss@mniewoehner.de>