### PR TITLE
Update libjpeg.hash

### DIFF
--- a/package/libjpeg/libjpeg.hash
+++ b/package/libjpeg/libjpeg.hash
@@ -1,3 +1,3 @@
 # locally computed hash
-sha256	99cb50e48a4556bc571dadd27931955ff458aae32f68c4d9c39d624693f69c32	jpegsrc.v9d.tar.gz
+sha256	b5cc67c43d1438fdb501207b71ba58dc44b3ffcfbcbb5d1c464a63877648a960	jpegsrc.v9d.tar.gz
 sha256	3dc4e4a145c907a96bd6a0e40be3f722fecf061951909143cdff5365cba9c78c	README


### PR DESCRIPTION
When running the `make` command I get:
```
ERROR: jpegsrc.v9d.tar.gz has wrong sha256 hash:
ERROR: expected: 99cb50e48a4556bc571dadd27931955ff458aae32f68c4d9c39d624693f69c32
ERROR: got     : b5cc67c43d1438fdb501207b71ba58dc44b3ffcfbcbb5d1c464a63877648a960
ERROR: Incomplete download, or man-in-the-middle (MITM) attack
```
this change should be fix it