### PR TITLE
package/gst-omx: fix gstomx.conf installation for raspberry

### DIFF
--- a/package/gstreamer1/gst-omx/gst-omx.mk
+++ b/package/gstreamer1/gst-omx/gst-omx.mk
@@ -17,10 +17,11 @@ GST_OMX_CONF_OPTS = \
 	-Dtools=disabled \
 	-Ddoc=disabled
 
+GST_OMX_VARIANT = generic
+
 ifeq ($(BR2_PACKAGE_RPI_USERLAND),y)
 GST_OMX_VARIANT = rpi
 GST_OMX_CONF_OPTS += -Dheader_path=$(STAGING_DIR)/usr/include/IL
-GST_OMX_VARIANT = generic
 endif
 
 GST_OMX_CONF_OPTS += -Dtarget=$(GST_OMX_VARIANT)


### PR DESCRIPTION
The commit 7e6f4e56 introduces a new bug when building the gst-omx package
for the raspberry.

GST_OMX_VARIANT variable in gst-omx.mk was shadowed to 'generic' after being
set well for raspberry. It results having the gstomx.conf not being installed,
and thus having gst-omx installed but none of its features available.

Signed-off-by: Augustin Thiercelin <augustin.thiercelin@procomm-mmc.com>