### PR TITLE
Update sdl2.mk to use SDL2-2.0.16

### DIFF
--- a/package/sdl2/sdl2.mk
+++ b/package/sdl2/sdl2.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SDL2_VERSION = 2.0.14
+SDL2_VERSION = 2.0.16
 SDL2_SOURCE = SDL2-$(SDL2_VERSION).tar.gz
 SDL2_SITE = http://www.libsdl.org/release
 SDL2_LICENSE = Zlib
@@ -21,6 +21,8 @@ SDL2_CONF_OPTS += \
 	--disable-dbus \
 	--disable-pulseaudio \
 	--disable-video-wayland
+# Raspberry Pi 4 (and other?) users who want to use SDL2 without X, but still
+# have OpenGLES could add --disable-video-opengl to SDL2_CONF_OPTS
 
 # We are using autotools build system for sdl2, so the sdl2-config.cmake
 # include path are not resolved like for sdl2-config script.


### PR DESCRIPTION
Latest SDL2, does not appear to break anything I've tested.
Added comment hint for RPI users to use OpenGLES without X