### PR TITLE
Feature/host python package config

### DIFF
--- a/package/python-aenum/python-aenum.mk
+++ b/package/python-aenum/python-aenum.mk
@@ -12,3 +12,4 @@ PYTHON_AENUM_LICENSE = BSD-3-Clause
 PYTHON_AENUM_LICENSE_FILES = aenum/LICENSE
 
 $(eval $(python-package))
+$(eval $(host-python-package))

--- a/package/python-can/python-can.mk
+++ b/package/python-can/python-can.mk
@@ -11,3 +11,4 @@ PYTHON_CAN_LICENSE = LGPL-3.0
 PYTHON_CAN_LICENSE_FILES = LICENSE.txt
 
 $(eval $(python-package))
+$(eval $(host-python-package))

--- a/package/python-wrapt/python-wrapt.mk
+++ b/package/python-wrapt/python-wrapt.mk
@@ -12,3 +12,4 @@ PYTHON_WRAPT_LICENSE = BSD-2-Clause
 PYTHON_WRAPT_LICENSE_FILES = LICENSE
 
 $(eval $(python-package))
+$(eval $(host-python-package))

--- a/package/python3/Config.in.host
+++ b/package/python3/Config.in.host
@@ -23,4 +23,9 @@ config BR2_PACKAGE_HOST_PYTHON3_SQLITE
         help
           sqlite module for host Python3.
 
+config BR2_PACKAGE_HOST_PYTHON3_CURSES
+        bool "curses"
+        help
+          curses module for host Python3.
+
 endif

--- a/package/python3/Config.in.host
+++ b/package/python3/Config.in.host
@@ -18,4 +18,9 @@ config BR2_PACKAGE_HOST_PYTHON3_SSL
 	help
 	  _ssl module for host Python3.
 
+config BR2_PACKAGE_HOST_PYTHON3_SQLITE
+        bool "sqlite"
+        help
+          sqlite module for host Python3.
+
 endif

--- a/package/python3/python3.mk
+++ b/package/python3/python3.mk
@@ -21,7 +21,6 @@ HOST_PYTHON3_CONF_OPTS += \
 	--without-cxx-main \
 	--disable-tk \
 	--with-expat=system \
-	--disable-curses \
 	--disable-codecs-cjk \
 	--disable-nis \
 	--enable-unicodedata \
@@ -56,6 +55,10 @@ endif
 
 ifneq ($(BR2_PACKAGE_HOST_PYTHON3_SQLITE),y)
 HOST_PYTHON3_CONF_OPTS += --disable-sqlite
+endif
+
+ifneq ($(BR2_PACKAGE_HOST_PYTHON3_CURSES),y)
+HOST_PYTHON3_CONF_OPTS += --disable-curses
 endif
 
 PYTHON3_INSTALL_STAGING = YES

--- a/package/python3/python3.mk
+++ b/package/python3/python3.mk
@@ -19,7 +19,6 @@ PYTHON3_CPE_ID_PRODUCT = python
 HOST_PYTHON3_CONF_OPTS += \
 	--without-ensurepip \
 	--without-cxx-main \
-	--disable-sqlite3 \
 	--disable-tk \
 	--with-expat=system \
 	--disable-curses \
@@ -53,6 +52,10 @@ ifeq ($(BR2_PACKAGE_HOST_PYTHON3_SSL),y)
 HOST_PYTHON3_DEPENDENCIES += host-openssl
 else
 HOST_PYTHON3_CONF_OPTS += --disable-openssl
+endif
+
+ifneq ($(BR2_PACKAGE_HOST_PYTHON3_SQLITE),y)
+HOST_PYTHON3_CONF_OPTS += --disable-sqlite
 endif
 
 PYTHON3_INSTALL_STAGING = YES


### PR DESCRIPTION
Ability to use python-cantools on host
adding host-python-package to aenum, can and wrapt
adding option to enable python3 sqlite and curses for host packages