### PR TITLE
package/urandom-scripts: hash old seed with new seed when saving

### DIFF
--- a/package/urandom-scripts/S20urandom
+++ b/package/urandom-scripts/S20urandom
@@ -17,26 +17,16 @@ else
 	pool_size=512
 fi
 
-check_file_size() {
-	[ -f "$URANDOM_SEED" ] || return 1
-	# Try to read two blocks but exactly one will be read if the file has
-	# the correct size.
-	size=$(dd if="$URANDOM_SEED" bs="$pool_size" count=2 2> /dev/null | wc -c)
-	test "$size" -eq "$pool_size"
-}
-
 init_rng() {
-	if check_file_size; then
-		printf 'Initializing random number generator: '
-		dd if="$URANDOM_SEED" bs="$pool_size" of=/dev/urandom count=1 2> /dev/null
-		status=$?
-		if [ "$status" -eq 0 ]; then
-			echo "OK"
-		else
-			echo "FAIL"
-		fi
-		return "$status"
+	printf 'Initializing random number generator: '
+	dd if="$URANDOM_SEED" bs="$pool_size" of=/dev/urandom count=1 2> /dev/null
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		echo "OK"
+	else
+		echo "FAIL"
 	fi
+	return "$status"
 }
 
 save_random_seed() {
@@ -44,7 +34,9 @@ save_random_seed() {
 	if touch "$URANDOM_SEED" 2> /dev/null; then
 		old_umask=$(umask)
 		umask 077
-		dd if=/dev/urandom of="$URANDOM_SEED" bs="$pool_size" count=1 2> /dev/null
+		dd if=/dev/urandom of="$URANDOM_SEED.new" bs="$pool_size" count=1 2> /dev/null
+		cat "$URANDOM_SEED" "$URANDOM_SEED.new" 2>/dev/null | sha256sum | cut -d ' ' -f 1 > "$URANDOM_SEED"
+		rm "$URANDOM_SEED.new"
 		status=$?
 		umask "$old_umask"
 		if [ "$status" -eq 0 ]; then


### PR DESCRIPTION
Writing into /dev/urandom doesn't actually credit any entropy bits. And while it adds that data to the entropy pool, it won't actually be immediately used when reading from /dev/urandom subsequently. This is how the kernel's /dev/urandom has always worked, unfortunately.

As a result of this behavior, which may be understandably surprising to you, writing a good seed file into /dev/urandom and then saving a new seed file immediately after is dangerous, because the new seed file may wind up being entirely deterministic, even if the old seed file was quite good.

I fixed this in systemd with <https://github.com/systemd/systemd/commit/da2862ef06f22fc8d31dafced6d2d6dc14f2ee0b>, and fortunately it's possible to do the same thing in shell script here. Specifically, instead of just saving new /dev/urandom output straight up, we hash the new /dev/urandom together with the old seed, in order to produce the new seed. This way the amount of entropy in the new seed will stay the same or get better, but not appreciably regress.

At the same time, the pool size check in this script is useless. Writing to /dev/urandom never credits bits anyway, so no matter what, writing into /dev/urandom is useful and not harmful. There's also not much of a point in seeding with more than 256 bits, which is what the hashing operation above produces. So this commit removes the file size check.

As a final note, while this commit improves upon the status quo by removing a vulnerability, this shell script still does not actually initialize the RNG like it says it does. For initialization via a seed file, the RNDADDENTROPY ioctl must be used.