### PR TITLE
Remove unrecognized option

### DIFF
--- a/package/m4/m4.mk
+++ b/package/m4/m4.mk
@@ -9,6 +9,5 @@ M4_SOURCE = m4-$(M4_VERSION).tar.xz
 M4_SITE = $(BR2_GNU_MIRROR)/m4
 M4_LICENSE = GPL-3.0+
 M4_LICENSE_FILES = COPYING
-HOST_M4_CONF_OPTS = --disable-static
 
 $(eval $(host-autotools-package))


### PR DESCRIPTION
`--disable-static` is an unrecognized option according to m4's configure script