### PR TITLE
package/oatpp:: add new package

### DIFF
--- a/package/Config.in
+++ b/package/Config.in
@@ -1941,6 +1941,7 @@ menu "Networking"
 	source "package/nss-mdns/Config.in"
 	source "package/nss-myhostname/Config.in"
 	source "package/nss-pam-ldapd/Config.in"
+	source "package/oatpp/Config.in"
 	source "package/omniorb/Config.in"
 	source "package/open-isns/Config.in"
 	source "package/open62541/Config.in"
@@ -2702,4 +2703,6 @@ menu "Text editors and viewers"
 	source "package/vim/Config.in"
 endmenu
 
+
 endmenu
+

--- a/package/oatpp/Config.in
+++ b/package/oatpp/Config.in
@@ -1,0 +1,14 @@
+comment "Oat++ needs a toolchain w/ C++, threads and Paranoid Unsafe Path compiler flag disabled"
+        depends on !BR2_INSTALL_LIBSTDCPP || !BR2_TOOLCHAIN_HAS_THREADS || BR2_COMPILER_PARANOID_UNSAFE_PATH
+
+config BR2_PACKAGE_OATPP
+	bool "Oat++"
+	depends on BR2_INSTALL_LIBSTDCPP
+	depends on BR2_TOOLCHAIN_HAS_THREADS
+	depends on !BR2_COMPILER_PARANOID_UNSAFE_PATH
+	help
+		Oat++ is an open-source C++ web framework for highly scalable and resource-efficient web applications.
+		It provides all the necessary components for production-grade development.
+		This package allows you to use oatpp to statically build this a project inside the staging directory.
+		See https://oatpp.io/docs/
+

--- a/package/oatpp/oatpp.mk
+++ b/package/oatpp/oatpp.mk
@@ -1,0 +1,16 @@
+################################################################################
+#
+# oatpp
+#
+################################################################################
+
+OATPP_VERSION= 1.3.0
+OATPP_SOURCE= $(OATPP_VERSION).tar.gz
+OATPP_SITE= https://github.com/oatpp/oatpp/archive/refs/tags
+#OATPP_SITE= git://github.com/oatpp/oatpp.git
+OATPP_INSTALL_STAGING= YES
+OATPP_INSTALL_TARGET= NO
+OATPP_MAKE=make
+
+$(eval $(cmake-package))
+


### PR DESCRIPTION
This package introduce oatpp in BR buildsystem. oatpp must be used as static linkable library in $(STAGING_DIR)/usr/include/oatpp-$(OATPP_VERSION)/oatpp for user that want to build theri own application by linking oatpp in a buildroot build system.

Signed-off-by: Alessandro Partesotti <a.partesotti@gmail.com>