### PR TITLE
fix access to "struct _frame" for Python >=3.11

### DIFF
--- a/package/python-sip/0002-fixframe.patch
+++ b/package/python-sip/0002-fixframe.patch
@@ -1,0 +1,44 @@
+Index: host-python-sip-4.19.25/siplib/sip.h
+===================================================================
+--- host-python-sip-4.19.25.orig/siplib/sip.h
++++ host-python-sip-4.19.25/siplib/sip.h
+@@ -1799,7 +1799,7 @@ typedef struct _sipAPIDef {
+     int (*api_get_time)(PyObject *, sipTimeDef *);
+     PyObject *(*api_from_time)(const sipTimeDef *);
+     int (*api_is_user_type)(const sipWrapperType *);
+-    struct _frame *(*api_get_frame)(int);
++    PyFrameObject *(*api_get_frame)(int);
+     int (*api_check_plugin_for_type)(const sipTypeDef *, const char *);
+     PyObject *(*api_unicode_new)(SIP_SSIZE_T, unsigned, int *, void **);
+     void (*api_unicode_write)(int, void *, int, unsigned);
+Index: host-python-sip-4.19.25/siplib/siplib.c
+===================================================================
+--- host-python-sip-4.19.25.orig/siplib/siplib.c
++++ host-python-sip-4.19.25/siplib/siplib.c
+@@ -448,7 +448,7 @@ static PyObject *sip_api_from_datetime(c
+ static int sip_api_get_time(PyObject *obj, sipTimeDef *time);
+ static PyObject *sip_api_from_time(const sipTimeDef *time);
+ static int sip_api_is_user_type(const sipWrapperType *wt);
+-static struct _frame *sip_api_get_frame(int);
++static PyFrameObject *sip_api_get_frame(int);
+ static int sip_api_check_plugin_for_type(const sipTypeDef *td,
+         const char *name);
+ static PyObject *sip_api_unicode_new(SIP_SSIZE_T len, unsigned maxchar,
+@@ -13741,13 +13741,13 @@ static int sip_api_is_user_type(const si
+ /*
+  * Return a frame from the execution stack.
+  */
+-static struct _frame *sip_api_get_frame(int depth)
++static PyFrameObject *sip_api_get_frame(int depth)
+ {
+-    struct _frame *frame = PyEval_GetFrame();
++    PyFrameObject *frame = PyEval_GetFrame();
+ 
+     while (frame != NULL && depth > 0)
+     {
+-        frame = frame->f_back;
++        frame = PyFrame_GetBack(frame);
+         --depth;
+     }
+ 
+


### PR DESCRIPTION
cf. https://docs.python.org/3/c-api/frame.html#c.PyFrame_GetBack

This fixes that python-sip does not compile. As python-sip is in the same state in master, I believe that this fix can and should be ported to master.