### PR TITLE
Add ddcutil package

### DIFF
--- a/package/ddcutil/Config.in
+++ b/package/ddcutil/Config.in
@@ -1,0 +1,12 @@
+config BR2_PACKAGE_DDCUTIL
+  bool "ddcutil"
+	select BR2_PACKAGE_UTIL_LINUX
+	select BR2_PACKAGE_UTIL_LINUX_LIBBLKID
+  select BR2_PACKAGE_EUDEV
+  select BR2_PACKAGE_JANSSON
+  select BR2_PACKAGE_LIBGLIB2
+  select BR2_PACKAGE_KMOD
+  select BR2_PACKAGE_UTIL_LINUX_LIBS
+  help
+  This is the ddcutil library https://www.ddcutil.com/
+

--- a/package/ddcutil/ddcutil.mk
+++ b/package/ddcutil/ddcutil.mk
@@ -1,0 +1,17 @@
+DDCUTIL_VERSION = 1.4.1-release
+DDCUTIL_SITE = $(call github,rockowitz,ddcutil,$(DDCUTIL_VERSION))
+DDCUTIL_DEPENDENCIES = host-pkgconf host-autoconf host-automake host-libtool libglib2 jansson util-linux eudev 
+HOST_DDCUTIL_DEPENDENCIES = host-util-linux
+DDCUTIL_CONF_OPTS = --disable-usb --disable-x11
+DDCUTIL_AUTORECONF = YES
+DDCUTIL_TOOLCHAIN_BUILDROOT_GLIBC=y
+
+define DDCUTIL_AUTORECONF_CMDS
+	$(info Running autoreconf...)
+	(cd $(@D); autoreconf -i -f -v)
+endef
+
+$(eval $(autotools-package))
+
+
+


### PR DESCRIPTION
This adds the https://www.ddcutil.com/ package to buildroot.

I'm working on a custom linux for RPI. The RPI is plugged into the monitor using HDMI and allows for your monitor to be network controlled, using the RPI.